### PR TITLE
refactor: apply browser decorator at class level

### DIFF
--- a/test.py
+++ b/test.py
@@ -495,17 +495,17 @@ class BaseParser:
         return None
 
 
+@browser(
+    block_images=True,
+    cache=True,
+    reuse_driver=True,
+    max_retry=3,
+    user_agent=random.choice(Config.USER_AGENTS),
+    headless=True,
+)
 class DromParser(BaseParser):
     """Парсер отзывов с Drom.ru"""
 
-    @browser(
-        block_images=True,
-        cache=True,
-        reuse_driver=True,
-        max_retry=3,
-        user_agent=random.choice(Config.USER_AGENTS),
-        headless=True,
-    )
     def parse_brand_model_reviews(self, driver: Driver, data: Dict) -> List[ReviewData]:
         """Парсинг отзывов для конкретной марки и модели"""
         brand = data["brand"]


### PR DESCRIPTION
## Summary
- move DromParser's browser decorator to class level to allow positional data calls

## Testing
- `python test.py parse --sources 3` *(fails: httpx.ProxyError: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689c00e5b9a48325bd6939b79e11c4fb