### PR TITLE
Disable caching in Drom and Drive2 parsers

### DIFF
--- a/test.py
+++ b/test.py
@@ -500,7 +500,7 @@ class DromParser(BaseParser):
 
     @browser(
         block_images=True,
-        cache=True,
+        cache=False,
         reuse_driver=True,
         max_retry=3,
         user_agent=random.choice(Config.USER_AGENTS),
@@ -670,7 +670,7 @@ class Drive2Parser(BaseParser):
 
     @browser(
         block_images=True,
-        cache=True,
+        cache=False,
         reuse_driver=True,
         max_retry=3,
         user_agent=random.choice(Config.USER_AGENTS),


### PR DESCRIPTION
## Summary
- turn off browser caching for Drom and Drive2 parsers to avoid serialization errors

## Testing
- `python test.py parse --sources 3` *(fails: httpx.ProxyError: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689bfcb6e6cc83258d232c619ab5c979