### PR TITLE
Remove class-level browser decorator from DromParser

### DIFF
--- a/auto_reviews_parser.py
+++ b/auto_reviews_parser.py
@@ -383,17 +383,24 @@ class BaseParser:
         
         return None
 
-@browser(
-    block_images=True,
-    cache=True,
-    reuse_driver=True,
-    max_retry=3,
-    user_agent=random.choice(Config.USER_AGENTS),
-    headless=True
-)
+# @browser(
+#     block_images=True,
+#     cache=True,
+#     reuse_driver=True,
+#     max_retry=3,
+#     user_agent=random.choice(Config.USER_AGENTS),
+#     headless=True
+# )
 class DromParser(BaseParser):
     """Парсер отзывов с Drom.ru"""
-    
+    @browser(
+        block_images=True,
+        cache=False,
+        reuse_driver=True,
+        max_retry=3,
+        user_agent=random.choice(Config.USER_AGENTS),
+        headless=True,
+    )
     def parse_brand_model_reviews(self, driver: Driver, data: Dict) -> List[ReviewData]:
         """Парсинг отзывов для конкретной марки и модели"""
         brand = data['brand']

--- a/test.py
+++ b/test.py
@@ -495,14 +495,14 @@ class BaseParser:
         return None
 
 
-@browser(
-    block_images=True,
-    cache=True,
-    reuse_driver=True,
-    max_retry=3,
-    user_agent=random.choice(Config.USER_AGENTS),
-    headless=True,
-)
+# @browser(
+#     block_images=True,
+#     cache=True,
+#     reuse_driver=True,
+#     max_retry=3,
+#     user_agent=random.choice(Config.USER_AGENTS),
+#     headless=True,
+# )
 class DromParser(BaseParser):
     """Парсер отзывов с Drom.ru"""
 


### PR DESCRIPTION
## Summary
- Disable class-level `@browser` decorator on `DromParser`
- Add method-level `@browser` decorator to `parse_brand_model_reviews`

## Testing
- `python test.py parse --sources 3` *(fails: httpx.ProxyError: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689c047a6cf48325ab781c547e07033c