### PR TITLE
Handle None reviews from parser

### DIFF
--- a/test.py
+++ b/test.py
@@ -1033,6 +1033,11 @@ class AutoReviewsParser:
             elif source == "drive2.ru":
                 # Вызываем метод с правильной сигнатурой
                 reviews = self.drive2_parser.parse_brand_model_reviews(data)
+            if reviews is None:
+                logging.warning(
+                    f"Parser returned no reviews for {brand} {model} on {source}"
+                )
+                reviews = []
 
             # Сохраняем отзывы в базу
             saved_count = 0


### PR DESCRIPTION
## Summary
- Guard against parsers returning None in `parse_single_source`
- Log warning when no reviews returned to aid debugging

## Testing
- `python -m py_compile test.py`


------
https://chatgpt.com/codex/tasks/task_e_689c07263a788325a11672f44dd41699