### PR TITLE
Resolve merge markers and update imports across project

### DIFF
--- a/auto_reviews_parser/requirements.txt
+++ b/auto_reviews_parser/requirements.txt
@@ -8,11 +8,7 @@ lxml>=4.9.0
 openpyxl>=3.0.0
 flask>=2.3.0
 python-dotenv>=1.0.0
-<<<<<<< HEAD
 prometheus-client>=0.16.0
 redis>=5.0.0
-
-=======
 pydantic>=1.10,<2.0
 pyyaml>=6.0
->>>>>>> origin/codex/create-settings.py-and-targets.yaml

--- a/auto_reviews_parser/src/analyzers/data_analyzer.py
+++ b/auto_reviews_parser/src/analyzers/data_analyzer.py
@@ -13,25 +13,19 @@ from typing import Dict, List, Tuple
 from pathlib import Path
 import json
 
-<<<<<<< HEAD
+from src.database.base import Database
 from src.utils.logger import get_logger
 from src.utils.validators import validate_non_empty_string
 
 logger = get_logger(__name__)
-=======
-from src.database.base import Database
->>>>>>> origin/codex/create-database-abstraction-and-repositories
 
 
 class ReviewsAnalyzer:
     """Анализатор собранных отзывов"""
 
     def __init__(self, db_path: str = "auto_reviews.db"):
-<<<<<<< HEAD
-        self.db_path = validate_non_empty_string(db_path, "db_path")
-=======
+        db_path = validate_non_empty_string(db_path, "db_path")
         self.db = Database(db_path)
->>>>>>> origin/codex/create-database-abstraction-and-repositories
         self.ensure_db_exists()
 
     def ensure_db_exists(self):

--- a/auto_reviews_parser/src/parsers/base_parser.py
+++ b/auto_reviews_parser/src/parsers/base_parser.py
@@ -1,31 +1,24 @@
-import random
-import time
 import re
 from datetime import datetime, timedelta
 from typing import Optional
 
-<<<<<<< HEAD
+from src.database.base import Database
+from src.utils.delay_manager import DelayManager
 from src.utils.logger import get_logger
+from src.utils.retry_decorator import retry_async
 from src.utils.validators import validate_not_none
 
 logger = get_logger(__name__)
-=======
-from src.utils.delay_manager import DelayManager
-from src.utils.retry_decorator import retry_async
->>>>>>> origin/codex/implement-delay-manager-and-retry-decorator
 
 
 class BaseParser:
     """Базовый парсер с общими утилитами"""
 
-<<<<<<< HEAD
-    def __init__(self, db):
+    def __init__(
+        self, db: Database, delay_manager: DelayManager | None = None
+    ) -> None:
         self.db = validate_not_none(db, "db")
-=======
-    def __init__(self, db, delay_manager: DelayManager | None = None):
-        self.db = db
         self.delay_manager = delay_manager or DelayManager()
->>>>>>> origin/codex/implement-delay-manager-and-retry-decorator
         self.session_stats = {
             "parsed": 0,
             "saved": 0,

--- a/auto_reviews_parser/src/parsers/drive2_parser.py
+++ b/auto_reviews_parser/src/parsers/drive2_parser.py
@@ -5,19 +5,11 @@ from urllib.parse import urljoin
 from botasaurus.browser import browser, Driver
 
 from .base_parser import BaseParser
-<<<<<<< HEAD:parsers/drive2_parser.py
-<<<<<<< HEAD
-from .models import ReviewData
+from src.models.review import Review
 from src.utils.logger import get_logger
 from src.utils.validators import validate_non_empty_string
 
 logger = get_logger(__name__)
-=======
-from src.models.review import Review
->>>>>>> origin/codex/create-review-model-and-update-parsers
-=======
-from src.models import ReviewData
->>>>>>> origin/codex/restructure-project-directory-and-update-imports:auto_reviews_parser/src/parsers/drive2_parser.py
 
 
 class Drive2Parser(BaseParser):

--- a/auto_reviews_parser/src/parsers/drom_parser.py
+++ b/auto_reviews_parser/src/parsers/drom_parser.py
@@ -5,19 +5,11 @@ from urllib.parse import urljoin
 from botasaurus.browser import browser, Driver
 
 from .base_parser import BaseParser
-<<<<<<< HEAD:parsers/drom_parser.py
-<<<<<<< HEAD
-from .models import ReviewData
+from src.models.review import Review
 from src.utils.logger import get_logger
 from src.utils.validators import validate_non_empty_string
 
 logger = get_logger(__name__)
-=======
-from src.models.review import Review
->>>>>>> origin/codex/create-review-model-and-update-parsers
-=======
-from src.models import ReviewData
->>>>>>> origin/codex/restructure-project-directory-and-update-imports:auto_reviews_parser/src/parsers/drom_parser.py
 
 
 class DromParser(BaseParser):

--- a/auto_reviews_parser/tests/unit/conftest.py
+++ b/auto_reviews_parser/tests/unit/conftest.py
@@ -62,16 +62,19 @@ sys.modules.setdefault("botasaurus.request", request_module)
 sys.modules.setdefault("botasaurus.soupify", soupify_module)
 sys.modules.setdefault("botasaurus.bt", bt_module)
 
-# Ensure project root is on the Python path
-ROOT_DIR = Path(__file__).resolve().parent.parent
-if str(ROOT_DIR) not in sys.path:
-    sys.path.insert(0, str(ROOT_DIR))
+# Ensure project directories are on the Python path
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PACKAGE_SRC = REPO_ROOT / "auto_reviews_parser" / "src"
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+if str(PACKAGE_SRC) not in sys.path:
+    sys.path.insert(0, str(PACKAGE_SRC))
 
 
 @pytest.fixture
 def test_db(tmp_path):
     """Provide a temporary database for tests."""
-    from auto_reviews_parser import ReviewsDatabase
+    from database import ReviewsDatabase
 
     db_path = tmp_path / "test.db"
     return ReviewsDatabase(str(db_path))
@@ -91,7 +94,7 @@ def parser_mocks():
 @pytest.fixture
 def auto_parser(parser_mocks):
     """AutoReviewsParser with mocked dependencies."""
-    from auto_reviews_parser import AutoReviewsParser
+    from services.auto_reviews_parser import AutoReviewsParser
 
     parser = AutoReviewsParser.__new__(AutoReviewsParser)
     parser.db = MagicMock()

--- a/auto_reviews_parser/tests/unit/integration/test_parser_manager.py
+++ b/auto_reviews_parser/tests/unit/integration/test_parser_manager.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from auto_reviews_parser import AutoReviewsParser
+from services.auto_reviews_parser import AutoReviewsParser
 
 
 @pytest.mark.parametrize("source", ["drom.ru", "drive2.ru"])

--- a/auto_reviews_parser/tests/unit/integration/test_reviews_database.py
+++ b/auto_reviews_parser/tests/unit/integration/test_reviews_database.py
@@ -1,8 +1,7 @@
 import sqlite3
 import pytest
 
-from parsers.models import ReviewData
-from auto_reviews_parser import ReviewsDatabase
+from src.models.review import Review
 
 
 def test_init_database_creates_tables(test_db):
@@ -14,15 +13,8 @@ def test_init_database_creates_tables(test_db):
     assert {"reviews", "parsing_stats", "sources_queue"} <= tables
 
 
-<<<<<<< HEAD:tests/integration/test_reviews_database.py
 def test_insert_and_duplicate_review(test_db):
-    review = ReviewData(
-=======
-def test_insert_and_duplicate_review(tmp_path):
-    db_path = tmp_path / "test.db"
-    db = ReviewsDatabase(str(db_path))
     review = Review(
->>>>>>> origin/codex/create-review-model-and-update-parsers:tests/test_reviews_database.py
         source="drom.ru",
         type="review",
         brand="Toyota",

--- a/auto_reviews_parser/tests/unit/unit/test_review_data.py
+++ b/auto_reviews_parser/tests/unit/unit/test_review_data.py
@@ -1,15 +1,7 @@
 import hashlib
 from datetime import datetime
 
-<<<<<<<< HEAD:auto_reviews_parser/tests/unit/unit/test_review_data.py
-<<<<<<<< HEAD:tests/unit/test_review_data.py
-from parsers.models import ReviewData
-========
 from src.models.review import Review
->>>>>>>> origin/codex/create-review-model-and-update-parsers:tests/test_review.py
-========
-from src.models import ReviewData
->>>>>>>> origin/codex/restructure-project-directory-and-update-imports:auto_reviews_parser/tests/unit/test_review_data.py
 
 
 def test_parsed_at_auto_set():


### PR DESCRIPTION
## Summary
- remove merge conflict markers and unify BaseParser with logger, database, and delay manager utilities
- standardize parser imports to use the new Review model and validation helpers
- clean up analyzer, requirements, and test modules for consistent dependencies

## Testing
- `pytest auto_reviews_parser/tests/unit/integration/test_reviews_database.py auto_reviews_parser/tests/unit/unit/test_review_data.py auto_reviews_parser/tests/unit/integration/test_parser_manager.py -q` *(fails: ImportError for Config and assertion in parser manager)*

------
https://chatgpt.com/codex/tasks/task_e_689cec13c5d4832584cc5f1ef2f3d6e0