### PR TITLE
Add parallel parsing service

### DIFF
--- a/auto_reviews_parser/src/services/__init__.py
+++ b/auto_reviews_parser/src/services/__init__.py
@@ -1,3 +1,4 @@
 from .auto_reviews_parser import AutoReviewsParser
+from .parallel_parser import ParallelParserService
 
-__all__ = ["AutoReviewsParser"]
+__all__ = ["AutoReviewsParser", "ParallelParserService"]

--- a/auto_reviews_parser/src/services/auto_reviews_parser.py
+++ b/auto_reviews_parser/src/services/auto_reviews_parser.py
@@ -9,7 +9,7 @@ import sqlite3
 import time
 import random
 from datetime import datetime, timedelta
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 import re
 import json
 import logging
@@ -21,6 +21,7 @@ from botasaurus.browser import browser, Driver
 from botasaurus.request import request, Request
 from botasaurus.soupify import soupify
 from botasaurus import bt
+from .parallel_parser import ParallelParserService
 
 # ==================== НАСТРОЙКИ ====================
 
@@ -353,6 +354,7 @@ class AutoReviewsParser:
         drom_parser: Optional[DromParser] = None,
         drive2_parser: Optional[Drive2Parser] = None,
         db_path: str = Config.DB_PATH,
+        max_workers: int = 4,
     ):
         """Создает экземпляр основного парсера.
 
@@ -369,6 +371,11 @@ class AutoReviewsParser:
         # Инициализация парсеров
         self.drom_parser = drom_parser or DromParser(self.db)
         self.drive2_parser = drive2_parser or Drive2Parser(self.db)
+        self.parsers: Dict[str, Any] = {
+            "drom.ru": self.drom_parser,
+            "drive2.ru": self.drive2_parser,
+        }
+        self.parallel_parser = ParallelParserService(self.parsers, max_workers)
 
     def setup_logging(self):
         """Настройка логирования"""
@@ -512,6 +519,54 @@ class AutoReviewsParser:
         except Exception as e:
             logging.error(f"Критическая ошибка парсинга {brand} {model} {source}: {e}")
             return False
+
+    def parse_multiple_sources(
+        self,
+        sources: List[Tuple[str, str, str]],
+        parallel: bool = False,
+    ) -> List[Tuple[Tuple[str, str, str], List[ReviewData]]]:
+        """Парсинг нескольких источников.
+
+        При ``parallel=True`` использует ``ThreadPoolExecutor``
+        через ``ParallelParserService``.
+        """
+
+        if parallel:
+            parse_results = self.parallel_parser.parse_multiple_sources(
+                sources, max_pages=Config.PAGES_PER_SESSION
+            )
+        else:
+            parse_results: List[Tuple[Tuple[str, str, str], List[ReviewData]]] = []
+            for brand, model, source in sources:
+                parser = self.parsers.get(source)
+                if parser is None:
+                    logging.warning(f"Unknown source: {source}")
+                    parse_results.append(((brand, model, source), []))
+                    continue
+                data = {
+                    "brand": brand,
+                    "model": model,
+                    "max_pages": Config.PAGES_PER_SESSION,
+                }
+                try:
+                    reviews = parser.parse_brand_model_reviews(data)
+                except Exception:
+                    logging.error(
+                        f"Ошибка парсинга {brand} {model} {source}", exc_info=True
+                    )
+                    reviews = []
+                parse_results.append(((brand, model, source), reviews))
+
+        for (brand, model, source), reviews in parse_results:
+            saved_count = 0
+            for review in reviews:
+                if self.db.save_review(review):
+                    saved_count += 1
+            self.mark_source_completed(
+                brand, model, source, Config.PAGES_PER_SESSION, saved_count
+            )
+
+        return parse_results
 
     def run_parsing_session(
         self, max_sources: int = 10, session_duration_hours: int = 2

--- a/auto_reviews_parser/src/services/parallel_parser.py
+++ b/auto_reviews_parser/src/services/parallel_parser.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Any, Dict, List, Tuple
+import logging
+
+
+class ParallelParserService:
+    """Run multiple parsers concurrently using a thread pool."""
+
+    def __init__(self, parsers: Dict[str, Any], max_workers: int = 4) -> None:
+        self.parsers = parsers
+        self.max_workers = max_workers
+
+    def _parse_source(
+        self,
+        brand: str,
+        model: str,
+        source: str,
+        base_params: Dict[str, Any],
+    ) -> Tuple[Tuple[str, str, str], List[Any]]:
+        parser = self.parsers.get(source)
+        if parser is None:
+            raise ValueError(f"Parser for source '{source}' not found")
+
+        params = dict(base_params)
+        params.update({"brand": brand, "model": model})
+        reviews = parser.parse_brand_model_reviews(params)
+        return (brand, model, source), reviews
+
+    def parse_multiple_sources(
+        self,
+        sources: List[Tuple[str, str, str]],
+        **base_params: Any,
+    ) -> List[Tuple[Tuple[str, str, str], List[Any]]]:
+        """Parse several sources concurrently.
+
+        Args:
+            sources: List of tuples ``(brand, model, source)``.
+            **base_params: Additional parameters passed to each parser.
+
+        Returns:
+            List of tuples ``((brand, model, source), reviews)``.
+        """
+
+        results: List[Tuple[Tuple[str, str, str], List[Any]]] = []
+        with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
+            futures = {
+                executor.submit(
+                    self._parse_source, brand, model, source, base_params
+                ): (brand, model, source)
+                for brand, model, source in sources
+            }
+
+            for future in as_completed(futures):
+                source_info = futures[future]
+                try:
+                    result = future.result()
+                except Exception:  # pragma: no cover - just logging
+                    logging.error(
+                        "Error parsing source %s", source_info, exc_info=True
+                    )
+                    result = (source_info, [])
+                results.append(result)
+
+        return results


### PR DESCRIPTION
## Summary
- add ParallelParserService using ThreadPoolExecutor to run parsers concurrently
- expose ParallelParserService and integrate it into AutoReviewsParser
- support parsing multiple sources in parallel or sequential modes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and syntax errors in tests)*

------
https://chatgpt.com/codex/tasks/task_e_689cec17f23083258d1ee208cca21db8