### PR TITLE
Add Prometheus metrics tracking for parsers

### DIFF
--- a/auto_reviews_parser/src/parsers/drive2_parser.py
+++ b/auto_reviews_parser/src/parsers/drive2_parser.py
@@ -5,6 +5,7 @@ from urllib.parse import urljoin
 from botasaurus.browser import browser, Driver
 
 from .base_parser import BaseParser
+from src.utils.metrics import track_parsing
 <<<<<<< HEAD:parsers/drive2_parser.py
 <<<<<<< HEAD
 from .models import ReviewData
@@ -23,6 +24,7 @@ from src.models import ReviewData
 class Drive2Parser(BaseParser):
     """Парсер отзывов и бортжурналов с Drive2.ru"""
 
+    @track_parsing("drive2.ru")
     @browser(
         block_images=True,
         cache=False,

--- a/auto_reviews_parser/src/parsers/drom_parser.py
+++ b/auto_reviews_parser/src/parsers/drom_parser.py
@@ -5,6 +5,7 @@ from urllib.parse import urljoin
 from botasaurus.browser import browser, Driver
 
 from .base_parser import BaseParser
+from src.utils.metrics import track_parsing
 <<<<<<< HEAD:parsers/drom_parser.py
 <<<<<<< HEAD
 from .models import ReviewData
@@ -23,6 +24,7 @@ from src.models import ReviewData
 class DromParser(BaseParser):
     """Парсер отзывов с Drom.ru"""
 
+    @track_parsing("drom.ru")
     @browser(
         block_images=True,
         cache=False,

--- a/auto_reviews_parser/src/services/auto_reviews_parser.py
+++ b/auto_reviews_parser/src/services/auto_reviews_parser.py
@@ -22,6 +22,8 @@ from botasaurus.request import request, Request
 from botasaurus.soupify import soupify
 from botasaurus import bt
 
+from src.utils.metrics import setup_metrics
+
 # ==================== НАСТРОЙКИ ====================
 
 
@@ -365,6 +367,8 @@ class AutoReviewsParser:
         self.db = db or ReviewsDatabase(db_path)
         self.setup_logging()
         self.session_id = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+        setup_metrics()
 
         # Инициализация парсеров
         self.drom_parser = drom_parser or DromParser(self.db)

--- a/auto_reviews_parser/src/utils/metrics.py
+++ b/auto_reviews_parser/src/utils/metrics.py
@@ -1,0 +1,66 @@
+"""Utilities for exposing Prometheus metrics for parsers."""
+from __future__ import annotations
+
+from functools import wraps
+from typing import Any, Callable, List
+
+from prometheus_client import Counter, Gauge, Histogram, start_http_server
+
+# Metrics definitions
+reviews_parsed = Counter(
+    "reviews_parsed_total",
+    "Number of reviews successfully parsed",
+    ["source"],
+)
+
+parse_duration = Histogram(
+    "parse_duration_seconds",
+    "Time spent parsing reviews",
+    ["source"],
+)
+
+parse_errors = Counter(
+    "parse_errors_total",
+    "Number of parsing errors",
+    ["source"],
+)
+
+active_parsers = Gauge(
+    "active_parsers",
+    "Currently active parser tasks",
+    ["source"],
+)
+
+_METRICS_STARTED = False
+
+
+def setup_metrics(port: int = 8000) -> None:
+    """Start HTTP server for exposing metrics if not already running."""
+    global _METRICS_STARTED
+    if not _METRICS_STARTED:
+        start_http_server(port)
+        _METRICS_STARTED = True
+
+
+def track_parsing(source: str) -> Callable[[Callable[..., List[Any]]], Callable[..., List[Any]]]:
+    """Decorator for tracking parsing metrics for a given source."""
+
+    def decorator(func: Callable[..., List[Any]]) -> Callable[..., List[Any]]:
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> List[Any]:
+            active_parsers.labels(source=source).inc()
+            try:
+                with parse_duration.labels(source=source).time():
+                    result = func(*args, **kwargs)
+                if isinstance(result, list):
+                    reviews_parsed.labels(source=source).inc(len(result))
+                return result
+            except Exception:
+                parse_errors.labels(source=source).inc()
+                raise
+            finally:
+                active_parsers.labels(source=source).dec()
+
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
## Summary
- expose Prometheus metrics and helper decorator to track parsing
- instrument Drom and Drive2 parsers with tracking decorator
- start metrics HTTP server during AutoReviewsParser initialization

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and syntax errors in existing test suite)*

------
https://chatgpt.com/codex/tasks/task_e_689cec18ae2083259b6171b9e7543d95