### PR TITLE
Resolve requirements conflict

### DIFF
--- a/auto_reviews_parser/requirements.txt
+++ b/auto_reviews_parser/requirements.txt
@@ -8,11 +8,7 @@ lxml>=4.9.0
 openpyxl>=3.0.0
 flask>=2.3.0
 python-dotenv>=1.0.0
-<<<<<<< HEAD
 prometheus-client>=0.16.0
 redis>=5.0.0
-
-=======
 pydantic>=1.10,<2.0
 pyyaml>=6.0
->>>>>>> origin/codex/create-settings.py-and-targets.yaml


### PR DESCRIPTION
## Summary
- merge dependency lists in auto_reviews_parser/requirements.txt to include Redis, Prometheus, Pydantic, PyYAML and others

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'auto_reviews_parser'; SyntaxError: conflict markers present)*

------
https://chatgpt.com/codex/tasks/task_e_689cec1acd6c83258539d19aff295995