### PR TITLE
Gracefully handle termination signals in CLI

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -8,6 +8,8 @@ work to :class:`ParserManager` from ``auto_reviews_parser``.
 from __future__ import annotations
 
 import argparse
+import signal
+import sys
 
 from dependency_injector import containers, providers
 
@@ -74,6 +76,26 @@ def main() -> None:
 
     container = Container()
     manager = container.parser_manager()
+
+    def shutdown_handler(signum, frame):
+        """Handle termination signals for graceful shutdown."""
+        print("\n🛑 Завершение работы по сигналу...")
+        try:
+            parser = getattr(manager, "parser", None)
+            if parser and hasattr(parser, "stop"):
+                parser.stop()
+            db = getattr(parser, "db", None)
+            close = getattr(db, "close", None)
+            if callable(close):
+                close()
+        finally:
+            try:
+                container.shutdown_resources()
+            finally:
+                sys.exit(0)
+
+    signal.signal(signal.SIGINT, shutdown_handler)
+    signal.signal(signal.SIGTERM, shutdown_handler)
 
     if args.command == "init":
         print("🚀 Инициализация парсера...")


### PR DESCRIPTION
## Summary
- Add SIGINT and SIGTERM handlers to CLI for graceful shutdown
- Attempt to stop parser and close resources before exiting

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'src.utils.metrics')*

------
https://chatgpt.com/codex/tasks/task_e_689cf2ca78248325b37b17e2db4ed091