### PR TITLE
feat: add JSON logging formatter

### DIFF
--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -1,4 +1,6 @@
+import json
 import logging
+import os
 from pathlib import Path
 from typing import Optional
 
@@ -8,20 +10,50 @@ LOG_DIR = Path("logs")
 LOG_DIR.mkdir(exist_ok=True)
 
 
-def get_logger(name: str, level: int = DEFAULT_LEVEL, log_file: Optional[str] = None) -> logging.Logger:
+class JSONFormatter(logging.Formatter):
+    """Format log records as JSON strings."""
+
+    def format(self, record: logging.LogRecord) -> str:  # noqa: D401 - simple json serialization
+        log_record = {
+            "timestamp": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        if record.exc_info:
+            log_record["exc_info"] = self.formatException(record.exc_info)
+        return json.dumps(log_record, ensure_ascii=False)
+
+
+def get_logger(
+    name: str,
+    level: int = DEFAULT_LEVEL,
+    log_file: Optional[str] = None,
+    json_format: Optional[bool] = None,
+) -> logging.Logger:
     """Return a configured logger with console and file handlers."""
     logger = logging.getLogger(name)
     if logger.handlers:
         return logger
 
+    if json_format is None:
+        fmt = os.getenv("LOG_FORMAT", "").lower()
+        if fmt:
+            json_format = fmt == "json"
+        else:
+            json_format = os.getenv("ENV", "").lower() == "production"
+
     logger.setLevel(level)
-    formatter = logging.Formatter(LOG_FORMAT)
+    formatter: logging.Formatter = (
+        JSONFormatter() if json_format else logging.Formatter(LOG_FORMAT)
+    )
 
     console_handler = logging.StreamHandler()
     console_handler.setFormatter(formatter)
     logger.addHandler(console_handler)
 
-    file_name = log_file or f"{name}.log"
+    suffix = "json" if json_format else "log"
+    file_name = log_file or f"{name}.{suffix}"
     file_handler = logging.FileHandler(LOG_DIR / file_name, encoding="utf-8")
     file_handler.setFormatter(formatter)
     logger.addHandler(file_handler)


### PR DESCRIPTION
## Summary
- add JSONFormatter for structured logging
- allow choosing plain or JSON log format via parameter or environment variables

## Testing
- `pytest` *(fails: No module named 'src.utils.metrics')*

------
https://chatgpt.com/codex/tasks/task_e_689cf2c81c9c8325b7d8f7b25a53c332