### PR TITLE
feat: allow external queue service

### DIFF
--- a/src/auto_reviews_parser/services/parser_service.py
+++ b/src/auto_reviews_parser/services/parser_service.py
@@ -21,7 +21,9 @@ class ParserService:
     ):
         self.queue_service = QueueService(db_path, Config.TARGET_BRANDS)
         self.export_service = ExportService(db_path)
-        self.parser = AutoReviewsParser(db_path, queue_service=self.queue_service)
+        self.parser = AutoReviewsParser(
+            db_path=db_path, queue_service=self.queue_service
+        )
         self.cache = cache
 
     def get_status_data(self) -> dict:


### PR DESCRIPTION
## Summary
- enable `AutoReviewsParser` to accept an optional `QueueService`
- delegate queue operations to the service with DB fallback
- ensure `ParserService` injects its queue service

## Testing
- `pytest -q`
- `PYTHONPATH=src MAX_SOURCES=0 python run_debug.py` *(fails: httpx.ProxyError: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689d0780f158832597f16fdda12e486f