### PR TITLE
Fix Drive2 parser URL and async function

### DIFF
--- a/src/auto_reviews_parser/parsers/drive2.py
+++ b/src/auto_reviews_parser/parsers/drive2.py
@@ -1,11 +1,15 @@
+import logging
 import re
-from typing import List
+from typing import Any, Dict, List
 from urllib.parse import urljoin
 
 from bs4 import BeautifulSoup
 
 from .base import BaseParser
 from .models import Review
+
+
+logger = logging.getLogger(__name__)
 
 
 class Drive2Parser(BaseParser):
@@ -80,7 +84,7 @@ class Drive2Parser(BaseParser):
 
         return review
 
-    def parse_brand_model_reviews(self, data: Dict[str, Any]) -> List[Review]:
+    async def parse_brand_model_reviews(self, data: Dict[str, Any]) -> List[Review]:
         """Парсинг отзывов для конкретной марки и модели"""
         brand = data.get("brand", "")
         model = data.get("model", "")
@@ -88,8 +92,8 @@ class Drive2Parser(BaseParser):
 
         reviews = []
 
-        # URL для поиска отзывов на drom.ru
-        base_url = f"https://www.drom.ru/reviews/{brand}/{model}/"
+        # URL для поиска отзывов на drive2.ru
+        base_url = f"https://www.drive2.ru/cars/{brand}/{model}/reviews/"
 
         for page in range(1, max_pages + 1):
             try:


### PR DESCRIPTION
## Summary
- Ensure Drive2 parser imports required types and logging
- Make Drive2 review parsing asynchronous and point to correct Drive2 URL

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689d764659048325ad902713ce3ddb29